### PR TITLE
🐛 fix azure openai 'choices' parameter is empty

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -162,7 +162,7 @@ export class ChatGPTApi implements LLMApi {
             const text = msg.data;
             try {
               const json = JSON.parse(text);
-              const delta = json.choices[0].delta.content;
+              const delta = json.choices[0]?.delta.content;
               if (delta) {
                 responseText += delta;
                 options.onUpdate?.(responseText, delta);


### PR DESCRIPTION
fix #47 
原因是 azure OpenAI 返回的第一行数据中 `choices` 可能是空列表。
<img width="569" alt="iShot_2023-11-08_17 22 19" src="https://github.com/Hk-Gosuto/ChatGPT-Next-Web-LangChain/assets/42402987/ada3cfa1-c4f9-43b5-b314-4958d87cf07b">

`ChatGPT-Next-Web` 原版 没有问题是因为 没有直接`throw e;` 只是打印了错误。
我看到你这里 Hk-Gosuto/ChatGPT-Next-Web-LangChain@a5bc735 添加了错误抛出，不太清楚是什么原因需要这样，所以没有改动你的逻辑。