### PR TITLE
修复插件页面描述会超出父容器(不换行)

### DIFF
--- a/app/components/plugin.tsx
+++ b/app/components/plugin.tsx
@@ -266,7 +266,8 @@ export function PluginPage() {
                       </div>
                     )}
                     {/* 描述 */}
-                    <div className={styles["plugin-info"] + " one-line"}>
+                    {/* Fix: descriptions do not wrap */}
+                    <div className={styles["plugin-info"]}>
                       {`${m.description}`}
                     </div>
                   </div>


### PR DESCRIPTION
## 问题

移动端下或调整浏览器窗口会导致插件描述超出

- 之前: 

<img width="291" alt="before-moblie" src="https://github.com/Yidadaa/ChatGPT-Next-Web/assets/133459587/0503c4e5-dd52-432f-a350-f711e091a4bd">

- 正常:

<img width="287" alt="after-mobile" src="https://github.com/Yidadaa/ChatGPT-Next-Web/assets/133459587/b3d6978f-3228-450d-86c8-5cf76d22be4c">

❤️ ❤️ 



