### PR TITLE
小小建议: 修改插件页面返回按钮适应整体风格

### DIFF
--- a/app/components/plugin.tsx
+++ b/app/components/plugin.tsx
@@ -223,13 +223,14 @@ export function PluginPage() {
   return (
     <ErrorBoundary>
       <div className={styles["plugin-page"]}>
-        <div className={styles["plugin-header"]}>
+        {/* <div className={styles["plugin-header"]}>
           <IconButton
             icon={<LeftIcon />}
             text={Locale.NewChat.Return}
             onClick={() => navigate(Path.Home)}
           ></IconButton>
-        </div>
+        </div> */}
+
         <div className="window-header">
           <div className="window-header-title">
             <div className="window-header-main-title">
@@ -240,7 +241,15 @@ export function PluginPage() {
             </div>
           </div>
 
-          <div className="window-actions"></div>
+          <div className="window-actions">
+            <div className="window-action-button">
+              <IconButton
+                icon={<CloseIcon />}
+                onClick={() => navigate(Path.Home)}
+                bordered
+              />
+            </div>
+          </div>
         </div>
 
         <div className={styles["plugin-page-body"]}>

--- a/app/components/plugin.tsx
+++ b/app/components/plugin.tsx
@@ -266,7 +266,8 @@ export function PluginPage() {
                       </div>
                     )}
                     {/* 描述 */}
-                    <div className={styles["plugin-info"] + " one-line"}>
+                    {/* Fix: descriptions do not wrap */}
+                    <div className={styles["plugin-info"]}>
                       {`${m.description}`}
                     </div>
                   </div>


### PR DESCRIPTION
## 原因

在面具页面中使用了顶部返回按钮，但是其标题在下半部分:

<img width="731" alt="Screenshot 2023-12-12 at 21 29 47" src="https://github.com/Hk-Gosuto/ChatGPT-Next-Web-LangChain/assets/133459587/a89ff8d8-8213-468c-909e-eadae4cbadd3">

但是插件页面使用类似整体设置页面的标题:

<img width="734" alt="Screenshot 2023-12-12 at 21 29 31" src="https://github.com/Hk-Gosuto/ChatGPT-Next-Web-LangChain/assets/133459587/40adb1cc-4e22-4d63-996b-13023acdbf2c">

修改为跟设置页面相同感觉更协调一点:

<img width="737" alt="Screenshot 2023-12-12 at 21 29 18" src="https://github.com/Hk-Gosuto/ChatGPT-Next-Web-LangChain/assets/133459587/88b55369-3d9f-4b63-8b75-92b17b424dc1">

**个人极其浅薄的见解，您要觉得不合理直接关闭PR就行** ❤️ 

建议您开启赞助，为您的功能点赞👍！




