### PR TITLE
chore(update): emoji-datasource-apple version to 15.0.1

### DIFF
--- a/app/components/emoji.tsx
+++ b/app/components/emoji.tsx
@@ -10,7 +10,7 @@ import BotIcon from "../icons/bot.svg";
 import BlackBotIcon from "../icons/black-bot.svg";
 
 export function getEmojiUrl(unified: string, style: EmojiStyle) {
-  return `https://cdn.staticfile.org/emoji-datasource-apple/14.0.0/img/${style}/64/${unified}.png`;
+  return `https://cdn.staticfile.org/emoji-datasource-apple/15.0.1/img/${style}/64/${unified}.png`;
 }
 
 export function AvatarPicker(props: {

--- a/app/components/plugin.tsx
+++ b/app/components/plugin.tsx
@@ -223,13 +223,14 @@ export function PluginPage() {
   return (
     <ErrorBoundary>
       <div className={styles["plugin-page"]}>
-        <div className={styles["plugin-header"]}>
+        {/* <div className={styles["plugin-header"]}>
           <IconButton
             icon={<LeftIcon />}
             text={Locale.NewChat.Return}
             onClick={() => navigate(Path.Home)}
           ></IconButton>
-        </div>
+        </div> */}
+
         <div className="window-header">
           <div className="window-header-title">
             <div className="window-header-main-title">
@@ -240,7 +241,15 @@ export function PluginPage() {
             </div>
           </div>
 
-          <div className="window-actions"></div>
+          <div className="window-actions">
+            <div className="window-action-button">
+              <IconButton
+                icon={<CloseIcon />}
+                onClick={() => navigate(Path.Home)}
+                bordered
+              />
+            </div>
+          </div>
         </div>
 
         <div className={styles["plugin-page-body"]}>

--- a/app/components/plugin.tsx
+++ b/app/components/plugin.tsx
@@ -266,7 +266,8 @@ export function PluginPage() {
                       </div>
                     )}
                     {/* 描述 */}
-                    <div className={styles["plugin-info"] + " one-line"}>
+                    {/* Fix: descriptions do not wrap */}
+                    <div className={styles["plugin-info"]}>
                       {`${m.description}`}
                     </div>
                   </div>


### PR DESCRIPTION
<img width="842" alt="Screenshot 2023-12-15 at 14 57 09" src="https://github.com/Hk-Gosuto/ChatGPT-Next-Web-LangChain/assets/133459587/a9b2dabc-2019-4531-a403-e495f5c9aa45">

今天突然发现面具和头像的emoji失效了，更新了emoji-datasource-apple版本为15.0.1