### PR TITLE
添加o1,o3,o4-mini为isVisionmodel. 其中o1,o3为可使用插件的isFunctionCallmodel

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -246,9 +246,10 @@ export class ChatGPTApi implements LLMApi {
       | GPTImageRequestPayload;
 
     const isImageGenModel = isOpenAIImageGenerationModel(options.config.model);
-    const isO1OrO3 =
+    const isO1Series =
       options.config.model.startsWith("o1") ||
-      options.config.model.startsWith("o3");
+      options.config.model.startsWith("o3") ||
+      options.config.model.startsWith("o4") ||;
 
     if (isImageGenModel) {
       const prompt = getMessageTextContent(
@@ -283,31 +284,32 @@ export class ChatGPTApi implements LLMApi {
         const content = visionModel
           ? await preProcessImageAndWebReferenceContent(v)
           : getWebReferenceMessageTextContent(v);
-        if (!(isO1OrO3 && v.role === "system"))
+        if (!(isOseries && v.role === "system"))
           messages.push({ role: v.role, content });
       }
 
-      // O1 not support image, tools (plugin in ChatGPTNextWeb) and system, stream, logprobs, temperature, top_p, n, presence_penalty, frequency_penalty yet.
+      // O1 support image, tools (except o4-mini for now) and system, stream, *NOT* logprobs, temperature, top_p, n, presence_penalty, frequency_penalty yet.
       requestPayload = {
         messages,
         stream: options.config.stream,
         model: modelConfig.model,
-        temperature: !isO1OrO3 ? modelConfig.temperature : 1,
-        presence_penalty: !isO1OrO3 ? modelConfig.presence_penalty : 0,
-        frequency_penalty: !isO1OrO3 ? modelConfig.frequency_penalty : 0,
-        top_p: !isO1OrO3 ? modelConfig.top_p : 1,
+        temperature: !isOseries ? modelConfig.temperature : 1,
+        presence_penalty: !isOseries ? modelConfig.presence_penalty : 0,
+        frequency_penalty: !isOseries ? modelConfig.frequency_penalty : 0,
+        top_p: !isOseries ? modelConfig.top_p : 1,
         // max_tokens: Math.max(modelConfig.max_tokens, 1024),
         // Please do not ask me why not send max_tokens, no reason, this param is just shit, I dont want to explain anymore.
       };
 
-      // O1 使用 max_completion_tokens 控制token数 (https://platform.openai.com/docs/guides/reasoning#controlling-costs)
-      if (isO1OrO3) {
-        requestPayload["max_completion_tokens"] = modelConfig.max_tokens;
-      }
 
       // add max_tokens to vision model
+      // O系列 使用 max_completion_tokens 控制token数 (https://platform.openai.com/docs/guides/reasoning#controlling-costs)
       if (visionModel) {
-        requestPayload["max_tokens"] = Math.max(modelConfig.max_tokens, 4000);
+        if (isOseries) {
+          requestPayload["max_completion_tokens"] = 23456;
+        } else {
+          requestPayload["max_tokens"] = Math.max(modelConfig.max_tokens, 4000);
+        }
       }
     }
 

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -246,7 +246,7 @@ export class ChatGPTApi implements LLMApi {
       | GPTImageRequestPayload;
 
     const isImageGenModel = isOpenAIImageGenerationModel(options.config.model);
-    const isOSeries =
+    const isOseries =
       options.config.model.startsWith("o1") ||
       options.config.model.startsWith("o3") ||
       options.config.model.startsWith("o4");

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -249,7 +249,7 @@ export class ChatGPTApi implements LLMApi {
     const isO1Series =
       options.config.model.startsWith("o1") ||
       options.config.model.startsWith("o3") ||
-      options.config.model.startsWith("o4") ||;
+      options.config.model.startsWith("o4");
 
     if (isImageGenModel) {
       const prompt = getMessageTextContent(

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -246,7 +246,7 @@ export class ChatGPTApi implements LLMApi {
       | GPTImageRequestPayload;
 
     const isImageGenModel = isOpenAIImageGenerationModel(options.config.model);
-    const isO1Series =
+    const isOSeries =
       options.config.model.startsWith("o1") ||
       options.config.model.startsWith("o3") ||
       options.config.model.startsWith("o4");

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -336,6 +336,9 @@ export const VISION_MODEL_REGEXES = [
   /gpt-4-turbo(?!.*preview)/, // Matches "gpt-4-turbo" but not "gpt-4-turbo-preview"
   /^dall-e-3$/, // Matches exactly "dall-e-3"
   /glm-4v/,
+  /o1/,
+  /o3/,
+  /o4/,
 ];
 
 export const EXCLUDE_VISION_MODEL_REGEXES = [/claude-3-5-haiku-20241022/];
@@ -368,14 +371,17 @@ const openaiModels = [
   "gpt-4.5-preview",
   "gpt-4.5-preview-2025-02-27",
   "dall-e-3",
+  "o1",
   "o1-mini",
   "o1-preview",
   "o1-pro",
   "o3-mini",
+  "o3",
   "gpt-4.1",
   "gpt-4.1-mini",
   "gpt-4.1-nano",
   "gpt-image-1",
+  "o4-mini",
 ];
 
 const googleModels = [

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -460,7 +460,7 @@ export function isFunctionCallModel(modelName: string) {
   ];
   if (specialModels.some((keyword) => modelName === keyword)) return true;
   return DEFAULT_MODELS.filter(
-    (model) => model.provider.id === "openai" && !model.name.includes("o2"),
+    (model) => model.provider.id === "openai" && !model.name.includes("o4-mini"),
   ).some((model) => model.name === modelName);
 }
 

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -336,6 +336,9 @@ export function isVisionModel(model: string) {
     "gpt-4.1",
     "gpt-4.1-mini",
     "gpt-4.1-nano",
+    "o1",
+    "o3",
+    "o4-mini",
   ];
 
   var googleModels = DEFAULT_MODELS.filter(
@@ -376,6 +379,7 @@ export function getTimeoutMSByModel(model: string) {
     model.startsWith("dalle") ||
     model.startsWith("o1") ||
     model.startsWith("o3") ||
+    model.startsWith("o4") ||
     model.includes("deepseek-r") ||
     model.includes("-thinking")
   )
@@ -450,10 +454,13 @@ export function isFunctionCallModel(modelName: string) {
     "claude-3-5-haiku-latest",
     "claude-3-7-sonnet-20250219",
     "claude-3-7-sonnet-latest",
+    "o1",
+    "o3",
+    "gpt-4.1",
   ];
   if (specialModels.some((keyword) => modelName === keyword)) return true;
   return DEFAULT_MODELS.filter(
-    (model) => model.provider.id === "openai" && !model.name.includes("o1"),
+    (model) => model.provider.id === "openai" && !model.name.includes("o2"),
   ).some((model) => model.name === modelName);
 }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [**x**] feat    <!-- 引入新功能 | Introduce new features -->
- [ ] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->
于constant.ts文件中，增加o1,o3,o4系列模型为**vision_regex const**/**openaimodels**；
于utils.ts文件中，增加o1,o3,o4系列模型为**isVisionmodel**; 增加o4系列模型为**getTimeoutMSByModel**；增加o1,o3,4.1模型为**isFunctionCallModel**，确保o4-mini模型不可用插件（具体原因为测试后发现当为o4-mini启用插件时，temperature等参数不可固定为1或其他值导致completion无法完成）;
于app/client/platforms/openai.ts中，修改isO1orO3为isOseries以及相应的命令。并修改if visionmodel 和 ifOseries的 max_token/max_completion_token的判断命令。

#### 📝 补充信息 | Additional Information

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->
相关模型vercel测试已通过，具体请看截图
![微信截图_20250428103937](https://github.com/user-attachments/assets/6265df7c-b8b3-47ec-b8a2-321aa4114074)
